### PR TITLE
Issue 16: EnumeratorCSVReader

### DIFF
--- a/app/src/main/java/ru/study21/jcsv/xxl/app/CutCommand.java
+++ b/app/src/main/java/ru/study21/jcsv/xxl/app/CutCommand.java
@@ -1,0 +1,63 @@
+package ru.study21.jcsv.xxl.app;
+
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+import ru.study21.jcsv.xxl.io.CuttingCSVReader;
+import ru.study21.jcsv.xxl.io.DefaultCSVReader;
+import ru.study21.jcsv.xxl.io.DefaultCSVWriter;
+
+import java.io.*;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static picocli.CommandLine.*;
+
+@Command(name = "cut")
+public class CutCommand implements Callable<Integer> {
+
+    @ParentCommand
+    private JCSVXXLApp parent;
+
+    @Option(names = "-i", required = true)
+    File inputFile;
+
+    @Option(names = "-l", required = true)
+    List<Integer> indices;
+
+    @Option(names = "-o", required = true)
+    File outputFile;
+
+    @Override
+    public Integer call() {
+        PrintWriter err = parent.spec.commandLine().getErr();
+
+        try (
+                BufferedReader br = new BufferedReader(new FileReader(inputFile));
+                BufferedWriter bw = new BufferedWriter(new FileWriter(outputFile))
+        ) {
+            CuttingCSVReader cuttingReader = new CuttingCSVReader(
+                    DefaultCSVReader.builder(br)
+                            .setHeader(parent.withHeader)
+                            .withSeparator(parent.separator)
+                            .build(),
+                    indices
+            );
+            DefaultCSVWriter writer = new DefaultCSVWriter(bw);
+
+            if (parent.withHeader) {
+                writer.write(cuttingReader.meta().toRow());
+            }
+            for (List<String> row = cuttingReader.nextRow(); !row.isEmpty(); row = cuttingReader.nextRow()) {
+                writer.write(row);
+            }
+
+        } catch (BrokenContentsException e) {
+            err.println("Broken file contents: " + e.getMessage());
+            return 1;
+        } catch (IOException e) {
+            err.println("IOException: " + e.getMessage());
+            return 2;
+        }
+        return 0;
+    }
+
+}

--- a/app/src/main/java/ru/study21/jcsv/xxl/app/JCSVXXLApp.java
+++ b/app/src/main/java/ru/study21/jcsv/xxl/app/JCSVXXLApp.java
@@ -11,7 +11,8 @@ import java.util.List;
         name = "jcsvxxl",
         subcommands = {
                 SummaryCommand.class,
-                SortCommand.class
+                SortCommand.class,
+                CutCommand.class
         })
 public class JCSVXXLApp {
 

--- a/app/src/test/java/ru/study21/jcsv/xxl/app/CutTest.java
+++ b/app/src/test/java/ru/study21/jcsv/xxl/app/CutTest.java
@@ -1,0 +1,25 @@
+package ru.study21.jcsv.xxl.app;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CutTest {
+
+    @Test
+    void testCut() throws IOException {
+        String path = "src/test/resources/sample_lf.csv";
+        String output = "src/test/resources/output.csv";
+        int code = new CommandLine(new JCSVXXLApp()).execute("-h", "cut", "-o", output, "-l", "1", "-l", "0", "-i", path);
+        Assertions.assertEquals(0, code);
+        Assertions.assertEquals("""
+                name2,name1
+                2,1
+                """, Files.readString(Path.of(output)).replace("\r", ""));
+    }
+
+}

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/common/CSVMeta.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/common/CSVMeta.java
@@ -5,6 +5,8 @@ package ru.study21.jcsv.xxl.common;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class CSVMeta {
     protected final Either<Integer, List<String>> _data;
@@ -51,5 +53,9 @@ public class CSVMeta {
             return Objects.equals(_data, ((CSVMeta) o)._data);
         }
         return false;
+    }
+
+    public List<String> toRow() {
+        return IntStream.range(0, size()).mapToObj(this::columnName).collect(Collectors.toList());
     }
 }

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/common/CSVMeta.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/common/CSVMeta.java
@@ -4,9 +4,10 @@
 package ru.study21.jcsv.xxl.common;
 
 import java.util.List;
+import java.util.Objects;
 
 public class CSVMeta {
-    private Either<Integer, List<String>> _data;
+    protected final Either<Integer, List<String>> _data;
 
     private CSVMeta(Either<Integer, List<String>> data) {
         _data = data;
@@ -42,5 +43,13 @@ public class CSVMeta {
 
     public boolean hasNames() {
         return _data.isRight();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(o instanceof CSVMeta) {
+            return Objects.equals(_data, ((CSVMeta) o)._data);
+        }
+        return false;
     }
 }

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/common/Either.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/common/Either.java
@@ -1,5 +1,7 @@
 package ru.study21.jcsv.xxl.common;
 
+import java.util.Objects;
+
 public class Either<T, U> {
     private final T _left;
     private final U _right;
@@ -39,5 +41,13 @@ public class Either<T, U> {
             return _right;
         }
         throw new IllegalStateException("it is not right");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Either) {
+            return Objects.equals(_left, ((Either<?, ?>) o)._left) && Objects.equals(_right, ((Either<?, ?>) o)._right);
+        }
+        return false;
     }
 }

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/common/Utility.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/common/Utility.java
@@ -1,0 +1,13 @@
+package ru.study21.jcsv.xxl.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Utility {
+
+    public static <T> List<T> slice(List<T> list, List<Integer> indices) {
+        return indices.stream().map(list::get).collect(Collectors.toList());
+    }
+
+}

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/io/CuttingCSVReader.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/io/CuttingCSVReader.java
@@ -1,0 +1,50 @@
+package ru.study21.jcsv.xxl.io;
+
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+import ru.study21.jcsv.xxl.common.CSVMeta;
+import ru.study21.jcsv.xxl.common.Utility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CuttingCSVReader implements CSVReader {
+
+    private final CSVReader delegate;
+    private final List<Integer> indices;
+
+    private final CSVMeta meta;
+
+    // can be used for a) cutting b) reordering
+    public CuttingCSVReader(CSVReader delegate, List<Integer> leaveIndices) {
+        this.delegate = delegate;
+        this.indices = leaveIndices;
+
+        if (delegate.meta().hasNames()) {
+            ArrayList<String> newNames = IntStream
+                    .range(0, delegate.meta().size())
+                    .mapToObj(i -> delegate.meta().columnName(i))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            meta = CSVMeta.withNames(Utility.slice(newNames, leaveIndices));
+        } else {
+            meta = CSVMeta.withoutNames(leaveIndices.size());
+        }
+    }
+
+    // TODO: add building with names (erasure signature conflicts, use builder?)
+
+    @Override
+    public CSVMeta meta() {
+        return meta;
+    }
+
+    @Override
+    public List<String> nextRow() throws BrokenContentsException {
+        List<String> row = delegate.nextRow();
+        if(row.size() == 0) {
+            return row;
+        }
+        return Utility.slice(row, indices);
+    }
+}

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/io/DefaultCSVReader.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/io/DefaultCSVReader.java
@@ -46,8 +46,8 @@ public class DefaultCSVReader implements CSVReader {
     }
 
     public static class Builder {
-        private boolean _withHeader = false;
-        private char _separator = ',';
+        private boolean _withHeader;
+        private char _separator;
         private final BufferedReader _reader;
 
         public Builder(BufferedReader reader) {
@@ -63,6 +63,11 @@ public class DefaultCSVReader implements CSVReader {
 
         public Builder withoutHeader() {
             _withHeader = false;
+            return this;
+        }
+
+        public Builder setHeader(boolean hasHeader) {
+            _withHeader = hasHeader;
             return this;
         }
 

--- a/utilities/src/main/java/ru/study21/jcsv/xxl/io/EnumeratorCSVReader.java
+++ b/utilities/src/main/java/ru/study21/jcsv/xxl/io/EnumeratorCSVReader.java
@@ -1,0 +1,44 @@
+package ru.study21.jcsv.xxl.io;
+
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+import ru.study21.jcsv.xxl.common.CSVMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// appends row number to the LAST column (for performance concerns)
+public class EnumeratorCSVReader implements CSVReader {
+
+    private final CSVReader delegate;
+    private final CSVMeta meta;
+
+    private long cnt = 0;
+
+    public EnumeratorCSVReader(CSVReader delegate) {
+        this.delegate = delegate;
+        if (delegate.meta().hasNames()) {
+            List<String> names = delegate.meta().toRow();
+            names.add(0, "");
+            meta = CSVMeta.withNames(names);
+        } else {
+            meta = CSVMeta.withoutNames(delegate.meta().size());
+        }
+    }
+
+    @Override
+    public CSVMeta meta() {
+        return meta;
+    }
+
+    @Override
+    public List<String> nextRow() throws BrokenContentsException {
+        List<String> row = new ArrayList<>(delegate.nextRow());
+        if(row.size() == 0) {
+            return row;
+        }
+        row.add(String.valueOf(cnt)); // performance concern
+        cnt++;
+        return row;
+    }
+}

--- a/utilities/src/test/java/ru/study21/jcsv/xxl/io/CuttingCSVReaderTest.java
+++ b/utilities/src/test/java/ru/study21/jcsv/xxl/io/CuttingCSVReaderTest.java
@@ -1,0 +1,40 @@
+package ru.study21.jcsv.xxl.io;
+
+import org.junit.jupiter.api.Test;
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+import ru.study21.jcsv.xxl.common.CSVMeta;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CuttingCSVReaderTest {
+
+    @Test
+    public void test() throws IOException, BrokenContentsException {
+        Path file = FileManager.createTempDirectory("CuttingCSVReaderTest").createTempFile("test");
+        String content = """
+                col1,col2,col3
+                1,a,x
+                2,b,y
+                3,c,z
+                """;
+        Files.writeString(file, content);
+
+        CuttingCSVReader cuttingReader = new CuttingCSVReader(
+                DefaultCSVReader.builder(Files.newBufferedReader(file)).withHeader().build(),
+                List.of(2, 1, 0, 1)
+        );
+
+        assertEquals(CSVMeta.withNames(List.of("col3", "col2", "col1", "col2")), cuttingReader.meta());
+        assertEquals(List.of("x", "a", "1", "a"), cuttingReader.nextRow());
+        assertEquals(List.of("y", "b", "2", "b"), cuttingReader.nextRow());
+        assertEquals(List.of("z", "c", "3", "c"), cuttingReader.nextRow());
+        assertEquals(List.of(), cuttingReader.nextRow());
+    }
+
+}

--- a/utilities/src/test/java/ru/study21/jcsv/xxl/io/DummyCSVReader.java
+++ b/utilities/src/test/java/ru/study21/jcsv/xxl/io/DummyCSVReader.java
@@ -1,0 +1,38 @@
+package ru.study21.jcsv.xxl.io;
+
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+import ru.study21.jcsv.xxl.common.CSVMeta;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class DummyCSVReader implements CSVReader {
+
+    private final Iterator<List<String>> tableIter;
+    private final CSVMeta meta;
+
+    public DummyCSVReader(List<List<String>> table, List<String> meta) {
+        if (table.size() == 0) {
+            throw new IllegalArgumentException("come on");
+        }
+        this.tableIter = table.iterator();
+        this.meta = (meta == null ? CSVMeta.withoutNames(table.get(0).size()) : CSVMeta.withNames(meta));
+    }
+
+    public DummyCSVReader(List<List<String>> table) {
+        this(table, null);
+    }
+
+    @Override
+    public CSVMeta meta() {
+        return meta;
+    }
+
+    @Override
+    public List<String> nextRow() {
+        if (tableIter.hasNext()) {
+            return tableIter.next();
+        }
+        return List.of();
+    }
+}

--- a/utilities/src/test/java/ru/study21/jcsv/xxl/io/EnumeratorCSVReaderTest.java
+++ b/utilities/src/test/java/ru/study21/jcsv/xxl/io/EnumeratorCSVReaderTest.java
@@ -1,0 +1,22 @@
+package ru.study21.jcsv.xxl.io;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ru.study21.jcsv.xxl.common.BrokenContentsException;
+
+import java.util.List;
+
+public class EnumeratorCSVReaderTest {
+
+    @Test
+    public void basicTest() throws BrokenContentsException {
+        DummyCSVReader dummy = new DummyCSVReader(List.of(
+                List.of("a"), List.of("b")
+        ));
+        EnumeratorCSVReader enumerator = new EnumeratorCSVReader(dummy);
+        Assertions.assertEquals(List.of("a", "0"), enumerator.nextRow());
+        Assertions.assertEquals(List.of("b", "1"), enumerator.nextRow());
+        Assertions.assertEquals(List.of(), enumerator.nextRow());
+    }
+
+}


### PR DESCRIPTION
So the pipeline for big-sort is supposed to be: 

DefaultCSVReader -> CutCSVReader (can rearrange columns) -> EnumeratorCSVReader -> BatchSorterCSVReader -> binarize -> k-way merge -> debinarize -> rearrange source file (this is the only step not implemented yet)

Also, this issue was started from `issue-8` because it contains some useful CSVMeta modifications I needed here.

Closes #16 